### PR TITLE
Make GNOME Shell display the app name as "Monocle"

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -19,6 +19,9 @@ class HomeWindow(Gtk.ApplicationWindow):
         self.appdata = home+"/.local/share/monocle/"
         self.nbpath = home+"/.monocle/"
 
+        # HomeWindow inherits the set_wmclass method from Gtk.ApplicationWindow
+        self.set_wmclass("Monocle", "Monocle")
+
         self.head = Gtk.HeaderBar.new()
         self.head.set_title("Monocle")
         self.head.set_show_close_button(True)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To test this system, you will need a testable "~/.local/share/monocle" and "~/.m
 - [ ] Make ability to add notebooks, sections, and pages - <OPEN>
 - [ ] Learn how to insert plain text editor widget - Bryden
 - [ ] Figure out how to set app icon and symbolic icon - <OPEN>
-- [ ] Figure out how to set GNOME shell app name - <OPEN>[Someone running the GNOME DE: Carter, Josh, Byron?]
+- [x] Figure out how to set GNOME shell app name - <OPEN>[Someone running the GNOME DE: Carter, Josh, Byron?]
 - [ ] Find a good text editor API (Render md / Type with formatting / Both) - EVERYONE
     -> Perhaps Quill? (It seems to be our best shot right now)
 - [ ] Learn how to run said editor - Carter, !Ben (As has been made clear)


### PR DESCRIPTION
This changes the name that appears in the top bar in GNOME Shell.